### PR TITLE
add custom field to apn message

### DIFF
--- a/Message/ApnMessage.php
+++ b/Message/ApnMessage.php
@@ -7,4 +7,6 @@ class ApnMessage implements IMessage {
   public $sound;
   public $actionLocKey;
   public $deviceToken;
+  
+  public $custom = array();
 }

--- a/Pusher/ApnPusher.php
+++ b/Pusher/ApnPusher.php
@@ -53,10 +53,12 @@ class ApnPusher implements IPusherStrategy {
           "sound" => $message->sound,
       );
 
-      $payload = json_encode($body);
+      $payload = array_merge($body, $message->custom)
+
+      $payloadJson = json_encode($payload);
 
       // Build the binary notification
-      $msg = chr(0) . pack("n", 32) . pack("H*", $message->deviceToken) . pack("n", strlen($payload)) . $payload;
+      $msg = chr(0) . pack("n", 32) . pack("H*", $message->deviceToken) . pack("n", strlen($payloadJson)) . $payload;
 
       $result = fwrite($fp, $msg, strlen($msg));
 


### PR DESCRIPTION
Providers can specify custom payload values outside the Apple-reserved aps namespace.
